### PR TITLE
Resolve contents from `getAllTrackers`

### DIFF
--- a/src/tracker.js
+++ b/src/tracker.js
@@ -11,7 +11,8 @@ async function getAllTrackers() {
         options.path = `/4/user/${accountDetails.uid}/trackers`;
         const req = https.request(options, function (res) {
             res.on('data', function(d) {
-                process.stdout.write(d + '\n\n');
+                let trackers = JSON.parse(d);
+                resolve(trackers)
             });
         });
         req.end();
@@ -127,4 +128,5 @@ module.exports = {
     getTrackerHistory: getTrackerHistory,
     getTrackerLocation: getTrackerLocation,
     getTrackerHardware: getTrackerHardware
+
 }


### PR DESCRIPTION
Currently, when you call `getAllTrackers` it prints the list of trackers to stdout, but doesn't ever resolve the Promise.

This resolves the parsed json in the same way as the other functions do.

---

Additional suggestion, using `fetch` might simplify some of the response parsing logic.  I'd be happy to raise an additional PR with those changes if you'd like?