### PR TITLE
Use `fetch`, modules and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-import https from 'https';
 import * as tAccount from './src/account.js';
 import * as tPet from './src/pet.js';
 import * as tTracker from './src/tracker.js';
@@ -28,40 +27,35 @@ globalThis.isAuthenticated = function() {
 }
 
 async function authenticate() {
-    return new Promise(function(resolve, reject) {/4/
-        const options = {
-            "method": "POST",
-            "hostname": "graph.tractive.com",
-            "path": `/4/auth/token?grant_type=tractive&platform_email=${encodeURIComponent(accountDetails.email)}&platform_token=${encodeURIComponent(accountDetails.password)}`,
-            "headers": {
-                'X-Tractive-Client': TractiveClient,
-                'Content-Type': "application/json"
+    const options = {
+        method: "POST",
+        headers: {
+            'X-Tractive-Client': TractiveClient,
+            'Content-Type': "application/json"
+        }
+    };
+
+    const url = `https://graph.tractive.com/4/auth/token?grant_type=tractive&platform_email=${encodeURIComponent(accountDetails.email)}&platform_token=${encodeURIComponent(accountDetails.password)}`;
+
+    try {
+        const res = await fetch(url, options);
+        const data = await res.json();
+        accountDetails.token = data.access_token;
+        accountDetails.uid = data.user_id;
+        gloOpts = {
+            method: "GET",
+            hostname: "graph.tractive.com",
+            path: ``,
+            headers: {
+                "X-Tractive-Client": TractiveClient,
+                "Authorization": `Bearer ${accountDetails.token}`,
+                "content-type": "application/json"
             }
         };
-        const req = https.request(options, function (res) {
-            res.on('data', function(d) {
-                // process.stdout.write(d + '\n\n');
-                accountDetails.token = JSON.parse(d).access_token;
-                accountDetails.uid = JSON.parse(d).user_id;
-                gloOpts = {
-                    method: "GET",
-                    hostname: "graph.tractive.com",
-                    path: ``,
-                    headers: {
-                        "X-Tractive-Client": TractiveClient,
-                        "Authorization": `Bearer ${accountDetails.token}`,
-                        "content-type": "application/json"
-                    }
-                };
-                resolve(true);
-            });
-            res.on('error', function(err) {
-                resolve(false);
-            });
-        });
-        req.end();
-    });
-    return promise;
+        return true;
+    } catch (err) {
+        return false;
+    }
 }
 
 async function connect(email, password) {
@@ -73,32 +67,24 @@ async function connect(email, password) {
 
 async function getTrackerGeofences(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/tracker/${trackerID}/geofences`;
-        const req = https.request(options, function (res) {
-            res.on('data', function(d) {
-                let data = JSON.parse(d);
-                resolve(data)
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/tracker/${trackerID}/geofences`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }
 
 async function getGeofence(fenceID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/geofence/${fenceID}`;
-        const req = https.request(options, function (res) {
-            res.on('data', function(d) {
-                let data = JSON.parse(d);
-                resolve(data)
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/geofence/${fenceID}`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }
 
 export default {

--- a/index.js
+++ b/index.js
@@ -1,14 +1,17 @@
-const https = require("https");
+import https from 'https';
+import * as tAccount from './src/account.js';
+import * as tPet from './src/pet.js';
+import * as tTracker from './src/tracker.js';
+import * as tCommands from './src/commands.js';
+
 const TractiveClient = "6536c228870a3c8857d452e8";
-const tAccount = require('./src/account');
-const tPet = require('./src/pet');
-const tTracker = require('./src/tracker');
-const tCommands = require('./src/commands');
-accountDetails = {
+
+globalThis.accountDetails = {
     email: "",
     password: ""
-}
-gloOpts = {
+};
+
+globalThis.gloOpts = {
     method: "GET",
     hostname: "graph.tractive.com",
     path: ``,
@@ -19,7 +22,7 @@ gloOpts = {
     }
 };
 
-isAuthenticated = function() {
+globalThis.isAuthenticated = function() {
     if(accountDetails?.token) return true;
     return false;
 }
@@ -98,24 +101,30 @@ async function getGeofence(fenceID) {
     });
 }
 
-module.exports = {
-    connect: connect,
-    isAuthenticated: isAuthenticated,
+export default {
+    connect,
+    isAuthenticated,
+    getTrackerGeofences,
+    getGeofence,
+    // Account
     getAccountInfo: tAccount.getAccountInfo,
     getAccountSubscriptions: tAccount.getAccountSubscriptions,
     getAccountSubscription: tAccount.getAccountSubscription,
     getAccountShares: tAccount.getAccountShares,
+    // Pet
     getPets: tPet.getPets,
     getPet: tPet.getPet,
+    // Tracker
     getAllTrackers: tTracker.getAllTrackers,
     getTracker: tTracker.getTracker,
     getTrackerHistory: tTracker.getTrackerHistory,
     getTrackerLocation: tTracker.getTrackerLocation,
     getTrackerHardware: tTracker.getTrackerHardware,
+    // Commands
     liveOn: tCommands.liveOn,
     liveOff: tCommands.liveOff,
     LEDOn: tCommands.LEDOn,
     LEDOff: tCommands.LEDOff,
     buzzerOn: tCommands.BuzzerOn,
     buzzerOff: tCommands.BuzzerOff
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "tractive",
+  "version": "1.2.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tractive",
+      "version": "1.2.1",
+      "license": "ISC",
+      "devDependencies": {
+        "undici": "^7.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
+      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Tractive API wrapper, using tractive.com services.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/FAXES/tractive/issues"
   },
-  "homepage": "https://github.com/FAXES/tractive#readme"
+  "homepage": "https://github.com/FAXES/tractive#readme",
+  "devDependencies": {
+    "undici": "^7.0.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.1",
   "description": "A Tractive API wrapper, using tractive.com services.",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "node --test"
   },

--- a/src/account.js
+++ b/src/account.js
@@ -1,29 +1,16 @@
-import https from 'https';
-
 /**
  * Gets Tractive account information.
  * @returns {Object} Object
  */
 export async function getAccountInfo() {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/user/${accountDetails.uid}`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    resolve(parsedData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/user/${accountDetails.uid}`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }
 
 /**
@@ -32,24 +19,13 @@ export async function getAccountInfo() {
  */
 export async function getAccountSubscriptions() {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/user/${accountDetails.uid}/subscriptions`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    resolve(parsedData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/user/${accountDetails.uid}/subscriptions`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }
 
 /**
@@ -59,24 +35,13 @@ export async function getAccountSubscriptions() {
  */
 export async function getAccountSubscription(subscriptionID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/subscription/${subscriptionID}`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    resolve(parsedData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/subscription/${subscriptionID}`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }
 
 /**
@@ -85,22 +50,11 @@ export async function getAccountSubscription(subscriptionID) {
  */
 export async function getAccountShares() {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/user/${accountDetails.uid}/shares`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    resolve(parsedData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/user/${accountDetails.uid}/shares`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }

--- a/src/account.js
+++ b/src/account.js
@@ -1,10 +1,10 @@
-const https = require("https");
+import https from 'https';
 
 /**
  * Gets Tractive account information.
  * @returns {Object} Object
  */
-async function getAccountInfo() {
+export async function getAccountInfo() {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -30,7 +30,7 @@ async function getAccountInfo() {
  * Get all account subscriptions
  * @returns {Array} Array
  */
-async function getAccountSubscriptions() {
+export async function getAccountSubscriptions() {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -57,7 +57,7 @@ async function getAccountSubscriptions() {
  * @param {String} subscriptionID 
  * @returns {Object} Object
  */
-async function getAccountSubscription(subscriptionID) {
+export async function getAccountSubscription(subscriptionID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -83,7 +83,7 @@ async function getAccountSubscription(subscriptionID) {
  * Get a list of accounts you share trackers with
  * @returns {Array} Array
  */
-async function getAccountShares() {
+export async function getAccountShares() {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -103,12 +103,4 @@ async function getAccountShares() {
         });
         req.end();
     });
-}
-
-
-module.exports = {
-    getAccountInfo: getAccountInfo,
-    getAccountSubscriptions: getAccountSubscriptions,
-    getAccountSubscription: getAccountSubscription,
-    getAccountShares: getAccountShares
 }

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,5 +1,3 @@
-import https from 'https';
-
 /**
  * Toggle live tracking mode on for a tracker.
  * @param {String} trackerID 
@@ -7,24 +5,13 @@ import https from 'https';
  */
 export async function liveOn(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/tracker/${trackerID}/command/live_tracking/on`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    resolve(parsedData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/tracker/${trackerID}/command/live_tracking/on`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }
 
 /**
@@ -34,24 +21,13 @@ export async function liveOn(trackerID) {
  */
 export async function liveOff(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/tracker/${trackerID}/command/live_tracking/off`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    resolve(parsedData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/tracker/${trackerID}/command/live_tracking/off`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }
 
 
@@ -62,24 +38,13 @@ export async function liveOff(trackerID) {
  */
 export async function LEDOn(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/tracker/${trackerID}/command/led_control/on`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    resolve(parsedData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/tracker/${trackerID}/command/led_control/on`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }
 
 /**
@@ -89,24 +54,13 @@ export async function LEDOn(trackerID) {
  */
 export async function LEDOff(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/tracker/${trackerID}/command/led_control/off`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    resolve(parsedData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/tracker/${trackerID}/command/led_control/off`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }
 
 
@@ -117,24 +71,13 @@ export async function LEDOff(trackerID) {
  */
 export async function BuzzerOn(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/tracker/${trackerID}/command/buzzer_control/on`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    resolve(parsedData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/tracker/${trackerID}/command/buzzer_control/on`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }
 
 /**
@@ -144,22 +87,11 @@ export async function BuzzerOn(trackerID) {
  */
 export async function BuzzerOff(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/tracker/${trackerID}/command/buzzer_control/off`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    resolve(parsedData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/tracker/${trackerID}/command/buzzer_control/off`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,11 +1,11 @@
-const https = require("https");
+import https from 'https';
 
 /**
  * Toggle live tracking mode on for a tracker.
  * @param {String} trackerID 
  * @returns {Object} Object
  */
-async function liveOn(trackerID) {
+export async function liveOn(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -32,7 +32,7 @@ async function liveOn(trackerID) {
  * @param {String} trackerID 
  * @returns {Object} Object
  */
-async function liveOff(trackerID) {
+export async function liveOff(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -60,7 +60,7 @@ async function liveOff(trackerID) {
  * @param {String} trackerID 
  * @returns {Object} Object
  */
-async function LEDOn(trackerID) {
+export async function LEDOn(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -87,7 +87,7 @@ async function LEDOn(trackerID) {
  * @param {String} trackerID 
  * @returns {Object} Object
  */
-async function LEDOff(trackerID) {
+export async function LEDOff(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -115,7 +115,7 @@ async function LEDOff(trackerID) {
  * @param {String} trackerID 
  * @returns {Object} Object
  */
-async function BuzzerOn(trackerID) {
+export async function BuzzerOn(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -142,7 +142,7 @@ async function BuzzerOn(trackerID) {
  * @param {String} trackerID 
  * @returns {Object} Object
  */
-async function BuzzerOff(trackerID) {
+export async function BuzzerOff(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -162,13 +162,4 @@ async function BuzzerOff(trackerID) {
         });
         req.end();
     });
-}
-
-module.exports = {
-    liveOn: liveOn,
-    liveOff: liveOff,
-    LEDOn: LEDOn,
-    LEDOff: LEDOff,
-    BuzzerOn: BuzzerOn,
-    BuzzerOff: BuzzerOff
 }

--- a/src/pet.js
+++ b/src/pet.js
@@ -1,11 +1,11 @@
-const https = require("https");
+import https from 'https';
 
 /**
  * Get a pet and it's data, includes attached tracker, type of animal, and other pet details.
  * @param {String} petID 
  * @returns {Object} Object
  */
-async function getPet(petID) {
+export async function getPet(petID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -33,7 +33,7 @@ async function getPet(petID) {
  * Get a list of all pets on the account
  * @returns {Array} Array
  */
-async function getPets() {
+export async function getPets() {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -53,9 +53,4 @@ async function getPets() {
         });
         req.end();
     });
-}
-
-module.exports = {
-    getPet: getPet,
-    getPets: getPets
 }

--- a/src/pet.js
+++ b/src/pet.js
@@ -1,5 +1,3 @@
-import https from 'https';
-
 /**
  * Get a pet and it's data, includes attached tracker, type of animal, and other pet details.
  * @param {String} petID 
@@ -7,26 +5,15 @@ import https from 'https';
  */
 export async function getPet(petID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/trackable_object/${petID}`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    parsedData.details.profile_picture_link = `https://graph.tractive.com/4/media/resource/${parsedData.details.profile_picture_id}.jpg`;
-                    parsedData.details.cover_picture_link = `https://graph.tractive.com/4/media/resource/${parsedData.details.cover_picture_id}.jpg`;
-                    resolve(parsedData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/trackable_object/${petID}`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const parsedData = await res.json();
+    parsedData.details.profile_picture_link = `https://graph.tractive.com/4/media/resource/${parsedData.details.profile_picture_id}.jpg`;
+    parsedData.details.cover_picture_link = `https://graph.tractive.com/4/media/resource/${parsedData.details.cover_picture_id}.jpg`;
+    return parsedData;
 }
 
 /**
@@ -35,22 +22,11 @@ export async function getPet(petID) {
  */
 export async function getPets() {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/user/${accountDetails.uid}/trackable_objects`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    // const parsedData = JSON.parse(rawData);
-                    resolve(rawData);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/user/${accountDetails.uid}/trackable_objects`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -1,22 +1,16 @@
-import https from 'https';
-
 /**
  * Get an array of all trackers on the account
  * @returns {Array}
  */
 export async function getAllTrackers() {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/user/${accountDetails.uid}/trackers`;
-        const req = https.request(options, function (res) {
-            res.on('data', function(d) {
-                let trackers = JSON.parse(d);
-                resolve(trackers)
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/user/${accountDetails.uid}/trackers`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const trackers = await res.json();
+    return trackers;
 }
 
 /**
@@ -26,17 +20,13 @@ export async function getAllTrackers() {
  */
 export async function getTracker(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/tracker/${trackerID}`;
-        const req = https.request(options, function (res) {
-            res.on('data', function(d) {
-                let tracker = JSON.parse(d);
-                resolve(tracker)
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/tracker/${trackerID}`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const tracker = await res.json();
+    return tracker;
 }
 
 /**
@@ -48,26 +38,15 @@ export async function getTracker(trackerID) {
  */
 export async function getTrackerHistory(trackerID, from, to) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let calcFrom = typeof from == "object" ? (from.getTime() / 1000).toFixed(0) : from;
-        let calcTo = typeof to == "object"  ? (to.getTime() / 1000).toFixed(0) : to;
-        let options = gloOpts;
-        options.path = `/4/tracker/${encodeURIComponent(trackerID)}/positions?time_from=${encodeURIComponent(calcFrom)}&time_to=${encodeURIComponent(calcTo)}&format=json_segments`;
-        const req = https.request(options, function (res) {
-            res.setEncoding('utf8');
-            let rawData = '';
-            res.on('data', (chunk) => { rawData += chunk; });
-            res.on('end', () => {
-                try {
-                    const parsedData = JSON.parse(rawData);
-                    resolve(parsedData[0]);
-                } catch (e) {
-                    console.error(e.message);
-                }
-            });
-        });
-        req.end();
+    let calcFrom = typeof from == "object" ? (from.getTime() / 1000).toFixed(0) : from;
+    let calcTo = typeof to == "object"  ? (to.getTime() / 1000).toFixed(0) : to;
+    const url = `https://graph.tractive.com/4/tracker/${encodeURIComponent(trackerID)}/positions?time_from=${encodeURIComponent(calcFrom)}&time_to=${encodeURIComponent(calcTo)}&format=json_segments`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const parsedData = await res.json();
+    return parsedData[0];
 }
 
 /**
@@ -77,29 +56,24 @@ export async function getTrackerHistory(trackerID, from, to) {
  */
 export async function getTrackerLocation(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/device_pos_report/${trackerID}`;
-        const req = https.request(options, function (res) {
-            res.on('data', function(d) {
-                let data = JSON.parse(d);
-                let options = gloOpts;
-                options.path = `/4/platform/geo/address/location?latitude=${encodeURIComponent(data.latlong[0])}&longitude=${encodeURIComponent(data.latlong[1])}`;
-                const req2 = https.request(options, function (res2) {
-                    res2.on('data', function(d2) {
-                        let address = JSON.parse(d2);
-                        data.address = address;
-                        resolve(data)
-                    });
-                    res2.on('error', function(err) {
-                        resolve(data)
-                    });
-                });
-                req2.end();
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/device_pos_report/${trackerID}`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    const addressUrl = `https://graph.tractive.com/4/platform/geo/address/location?latitude=${encodeURIComponent(data.latlong[0])}&longitude=${encodeURIComponent(data.latlong[1])}`;
+    try {
+        const addressRes = await fetch(addressUrl, {
+            method: gloOpts.method,
+            headers: gloOpts.headers
+        });
+        const address = await addressRes.json();
+        data.address = address;
+    } catch (err) {
+        // ignore address fetch error
+    }
+    return data;
 }
 
 /**
@@ -109,15 +83,11 @@ export async function getTrackerLocation(trackerID) {
  */
 export async function getTrackerHardware(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
-    return new Promise(function(resolve, reject) {
-        let options = gloOpts;
-        options.path = `/4/device_hw_report/${trackerID}`;
-        const req = https.request(options, function (res) {
-            res.on('data', function(d) {
-                let data = JSON.parse(d);
-                resolve(data)
-            });
-        });
-        req.end();
+    const url = `https://graph.tractive.com/4/device_hw_report/${trackerID}`;
+    const res = await fetch(url, {
+        method: gloOpts.method,
+        headers: gloOpts.headers
     });
+    const data = await res.json();
+    return data;
 }

--- a/src/tracker.js
+++ b/src/tracker.js
@@ -1,10 +1,10 @@
-const https = require("https");
+import https from 'https';
 
 /**
  * Get an array of all trackers on the account
  * @returns {Array}
  */
-async function getAllTrackers() {
+export async function getAllTrackers() {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -24,7 +24,7 @@ async function getAllTrackers() {
  * @param {String} trackerID 
  * @returns {Object} Object
  */
-async function getTracker(trackerID) {
+export async function getTracker(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -46,7 +46,7 @@ async function getTracker(trackerID) {
  * @param {Number} to 
  * @returns {Array} Array
  */
-async function getTrackerHistory(trackerID, from, to) {
+export async function getTrackerHistory(trackerID, from, to) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let calcFrom = typeof from == "object" ? (from.getTime() / 1000).toFixed(0) : from;
@@ -75,7 +75,7 @@ async function getTrackerHistory(trackerID, from, to) {
  * @param {String} trackerID 
  * @returns {Object} Object
  */
-async function getTrackerLocation(trackerID) {
+export async function getTrackerLocation(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -107,7 +107,7 @@ async function getTrackerLocation(trackerID) {
  * @param {String} trackerID 
  * @returns {Object} Object
  */
-async function getTrackerHardware(trackerID) {
+export async function getTrackerHardware(trackerID) {
     if(!isAuthenticated()) return console.log('Not authenticated.');
     return new Promise(function(resolve, reject) {
         let options = gloOpts;
@@ -120,13 +120,4 @@ async function getTrackerHardware(trackerID) {
         });
         req.end();
     });
-}
-
-module.exports = {
-    getAllTrackers: getAllTrackers,
-    getTracker: getTracker,
-    getTrackerHistory: getTrackerHistory,
-    getTrackerLocation: getTrackerLocation,
-    getTrackerHardware: getTrackerHardware
-
 }

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -55,24 +55,18 @@ describe('Account', () => {
         setGlobalDispatcher(originalDispatcher);
     });
 
-  describe('getAccountInfo', () => {
-    test('should fetch account information', async () => {
-        const result = await account.getAccountInfo();
-        assert.deepStrictEqual(result, { id: 'test-user-id', name: 'Test User' });
-    });
+  test('getAccountInfo', async () => {
+    const result = await account.getAccountInfo();
+    assert.deepStrictEqual(result, { id: 'test-user-id', name: 'Test User' });
   });
 
-  describe('getAccountSubscriptions', () => {
-    test('should fetch account subscriptions', async () => {
-        const result = await account.getAccountSubscriptions();
-        assert.deepStrictEqual(result, [{ id: 'sub-1', status: 'active' }]);
-    });
+  test('getAccountSubscriptions', async () => {
+    const result = await account.getAccountSubscriptions();
+    assert.deepStrictEqual(result, [{ id: 'sub-1', status: 'active' }]);
   });
 
-  describe('getAccountShares', () => {
-    test('should fetch account shares', async () => {
-        const result = await account.getAccountShares();
-        assert.deepStrictEqual(result, [{ id: 'share-1', email: 'friend@example.com' }]);
-    });
+  test('getAccountShares', async () => {
+    const result = await account.getAccountShares();
+    assert.deepStrictEqual(result, [{ id: 'share-1', email: 'friend@example.com' }]);
   });
 });

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -1,25 +1,78 @@
-import { test, describe } from 'node:test';
+import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
+import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from 'undici';
+import * as account from '../src/account.js';
+
+// Set up global scope for modules
+globalThis.accountDetails = {
+    uid: "test-user-id",
+    token: "test-token"
+};
+
+globalThis.gloOpts = {
+    method: "GET",
+    hostname: "graph.tractive.com",
+    headers: {
+        "X-Tractive-Client": "mock-client",
+        "Authorization": `Bearer mock-auth`,
+        "content-type": "application/json"
+    }
+};
+
+globalThis.isAuthenticated = function () {
+    if (accountDetails?.token) return true;
+    return false;
+}
+
+// Set up mock agent and interceptors
+const accountMock = new MockAgent();
+const mockPool = accountMock.get('https://graph.tractive.com');
+
+// Set up all mock interceptors
+mockPool.intercept({
+    path: `/4/user/test-user-id`,
+    method: 'GET'
+}).reply(200, { id: 'test-user-id', name: 'Test User' });
+
+mockPool.intercept({
+    path: `/4/user/test-user-id/subscriptions`,
+    method: 'GET'
+}).reply(200, [{ id: 'sub-1', status: 'active' }]);
+
+mockPool.intercept({
+    path: `/4/user/test-user-id/shares`,
+    method: 'GET'
+}).reply(200, [{ id: 'share-1', email: 'friend@example.com' }]);
+
+const originalDispatcher = getGlobalDispatcher();
 
 describe('Account', () => {
+    beforeEach(() => {
+        setGlobalDispatcher(accountMock);
+    });
+
+    afterEach(() => {
+        setGlobalDispatcher(originalDispatcher);
+    });
+
   describe('getAccountInfo', () => {
     test('should fetch account information', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const result = await account.getAccountInfo();
+        assert.deepStrictEqual(result, { id: 'test-user-id', name: 'Test User' });
     });
   });
 
   describe('getAccountSubscriptions', () => {
     test('should fetch account subscriptions', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const result = await account.getAccountSubscriptions();
+        assert.deepStrictEqual(result, [{ id: 'sub-1', status: 'active' }]);
     });
   });
 
   describe('getAccountShares', () => {
     test('should fetch account shares', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const result = await account.getAccountShares();
+        assert.deepStrictEqual(result, [{ id: 'share-1', email: 'friend@example.com' }]);
     });
   });
 });

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -1,0 +1,25 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+
+describe('Account', () => {
+  describe('getAccountInfo', () => {
+    test('should fetch account information', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+
+  describe('getAccountSubscriptions', () => {
+    test('should fetch account subscriptions', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+
+  describe('getAccountShares', () => {
+    test('should fetch account shares', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+});

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1,0 +1,46 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+
+describe('Commands', () => {
+  describe('liveOn', () => {
+    test('should enable live tracking', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+
+  describe('liveOff', () => {
+    test('should disable live tracking', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+
+  describe('LEDOn', () => {
+    test('should turn on LED', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+
+  describe('LEDOff', () => {
+    test('should turn off LED', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+
+  describe('BuzzerOn', () => {
+    test('should turn on buzzer', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+
+  describe('BuzzerOff', () => {
+    test('should turn off buzzer', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+});

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -70,45 +70,33 @@ describe('Commands', () => {
         setGlobalDispatcher(originalDispatcher);
     });
 
-  describe('liveOn', () => {
-    test('should enable live tracking', async () => {
-        const result = await commands.liveOn('tracker-1');
-        assert.deepStrictEqual(result, { status: 'success' });
-    });
+  test('liveOn', async () => {
+      const result = await commands.liveOn('tracker-1');
+      assert.deepStrictEqual(result, { status: 'success' });
   });
 
-  describe('liveOff', () => {
-    test('should disable live tracking', async () => {
-        const result = await commands.liveOff('tracker-1');
-        assert.deepStrictEqual(result, { status: 'success' });
-    });
+  test('liveOff', async () => {
+      const result = await commands.liveOff('tracker-1');
+      assert.deepStrictEqual(result, { status: 'success' });
   });
 
-  describe('LEDOn', () => {
-    test('should turn on LED', async () => {
-        const result = await commands.LEDOn('tracker-1');
-        assert.deepStrictEqual(result, { status: 'success' });
-    });
+  test('LEDOn', async () => {
+      const result = await commands.LEDOn('tracker-1');
+      assert.deepStrictEqual(result, { status: 'success' });
   });
 
-  describe('LEDOff', () => {
-    test('should turn off LED', async () => {
-        const result = await commands.LEDOff('tracker-1');
-        assert.deepStrictEqual(result, { status: 'success' });
-    });
+  test('LEDOff', async () => {
+      const result = await commands.LEDOff('tracker-1');
+      assert.deepStrictEqual(result, { status: 'success' });
   });
 
-  describe('BuzzerOn', () => {
-    test('should turn on buzzer', async () => {
-        const result = await commands.BuzzerOn('tracker-1');
-        assert.deepStrictEqual(result, { status: 'success' });
-    });
+  test('BuzzerOn', async () => {
+      const result = await commands.BuzzerOn('tracker-1');
+      assert.deepStrictEqual(result, { status: 'success' });
   });
 
-  describe('BuzzerOff', () => {
-    test('should turn off buzzer', async () => {
-        const result = await commands.BuzzerOff('tracker-1');
-        assert.deepStrictEqual(result, { status: 'success' });
-    });
+  test('BuzzerOff', async () => {
+      const result = await commands.BuzzerOff('tracker-1');
+      assert.deepStrictEqual(result, { status: 'success' });
   });
 });

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -1,46 +1,114 @@
-import { test, describe } from 'node:test';
+import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
+import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from 'undici';
+import * as commands from '../src/commands.js';
+
+// Set up global scope for modules
+globalThis.accountDetails = {
+    uid: "test-user-id",
+    token: "test-token"
+};
+
+globalThis.gloOpts = {
+    method: "GET",
+    hostname: "graph.tractive.com",
+    headers: {
+        "X-Tractive-Client": "mock-client",
+        "Authorization": `Bearer mock-auth`,
+        "content-type": "application/json"
+    }
+};
+
+globalThis.isAuthenticated = function () {
+    if (accountDetails?.token) return true;
+    return false;
+}
+
+// Set up mock agent and interceptors
+const commandsMock = new MockAgent();
+const mockPool = commandsMock.get('https://graph.tractive.com');
+
+// Set up all mock interceptors
+mockPool.intercept({
+    path: `/4/tracker/tracker-1/command/live_tracking/on`,
+    method: 'GET'
+}).reply(200, { status: 'success' });
+
+mockPool.intercept({
+    path: `/4/tracker/tracker-1/command/live_tracking/off`,
+    method: 'GET'
+}).reply(200, { status: 'success' });
+
+mockPool.intercept({
+    path: `/4/tracker/tracker-1/command/led_control/on`,
+    method: 'GET'
+}).reply(200, { status: 'success' });
+
+mockPool.intercept({
+    path: `/4/tracker/tracker-1/command/led_control/off`,
+    method: 'GET'
+}).reply(200, { status: 'success' });
+
+mockPool.intercept({
+    path: `/4/tracker/tracker-1/command/buzzer_control/on`,
+    method: 'GET'
+}).reply(200, { status: 'success' });
+
+mockPool.intercept({
+    path: `/4/tracker/tracker-1/command/buzzer_control/off`,
+    method: 'GET'
+}).reply(200, { status: 'success' });
+
+const originalDispatcher = getGlobalDispatcher();
 
 describe('Commands', () => {
+    beforeEach(() => {
+        setGlobalDispatcher(commandsMock);
+    });
+
+    afterEach(() => {
+        setGlobalDispatcher(originalDispatcher);
+    });
+
   describe('liveOn', () => {
     test('should enable live tracking', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const result = await commands.liveOn('tracker-1');
+        assert.deepStrictEqual(result, { status: 'success' });
     });
   });
 
   describe('liveOff', () => {
     test('should disable live tracking', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const result = await commands.liveOff('tracker-1');
+        assert.deepStrictEqual(result, { status: 'success' });
     });
   });
 
   describe('LEDOn', () => {
     test('should turn on LED', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const result = await commands.LEDOn('tracker-1');
+        assert.deepStrictEqual(result, { status: 'success' });
     });
   });
 
   describe('LEDOff', () => {
     test('should turn off LED', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const result = await commands.LEDOff('tracker-1');
+        assert.deepStrictEqual(result, { status: 'success' });
     });
   });
 
   describe('BuzzerOn', () => {
     test('should turn on buzzer', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const result = await commands.BuzzerOn('tracker-1');
+        assert.deepStrictEqual(result, { status: 'success' });
     });
   });
 
   describe('BuzzerOff', () => {
     test('should turn off buzzer', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const result = await commands.BuzzerOff('tracker-1');
+        assert.deepStrictEqual(result, { status: 'success' });
     });
   });
 });

--- a/test/pet.test.js
+++ b/test/pet.test.js
@@ -1,0 +1,11 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+
+describe('Pet', () => {
+  describe('getPets', () => {
+    test('should fetch all pets', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+});

--- a/test/pet.test.js
+++ b/test/pet.test.js
@@ -1,11 +1,54 @@
-import { test, describe } from 'node:test';
+import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
+import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from 'undici';
+import * as pet from '../src/pet.js';
+
+// Set up global scope for modules
+globalThis.accountDetails = {
+    uid: "test-user-id",
+    token: "test-token"
+};
+
+globalThis.gloOpts = {
+    method: "GET",
+    hostname: "graph.tractive.com",
+    headers: {
+        "X-Tractive-Client": "mock-client",
+        "Authorization": `Bearer mock-auth`,
+        "content-type": "application/json"
+    }
+};
+
+globalThis.isAuthenticated = function () {
+    if (accountDetails?.token) return true;
+    return false;
+}
+
+// Set up mock agent and interceptors
+const petMock = new MockAgent();
+const mockPool = petMock.get('https://graph.tractive.com');
+
+// Set up all mock interceptors
+mockPool.intercept({
+    path: `/4/user/test-user-id/trackable_objects`,
+    method: 'GET'
+}).reply(200, [{ id: 'pet-1', name: 'Fluffy', type: 'dog' }]);
+
+const originalDispatcher = getGlobalDispatcher();
 
 describe('Pet', () => {
+    beforeEach(() => {
+        setGlobalDispatcher(petMock);
+    });
+
+    afterEach(() => {
+        setGlobalDispatcher(originalDispatcher);
+    });
+
   describe('getPets', () => {
     test('should fetch all pets', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const result = await pet.getPets();
+        assert.deepStrictEqual(result, [{ id: 'pet-1', name: 'Fluffy', type: 'dog' }]);
     });
   });
 });

--- a/test/pet.test.js
+++ b/test/pet.test.js
@@ -45,10 +45,8 @@ describe('Pet', () => {
         setGlobalDispatcher(originalDispatcher);
     });
 
-  describe('getPets', () => {
-    test('should fetch all pets', async () => {
-        const result = await pet.getPets();
-        assert.deepStrictEqual(result, [{ id: 'pet-1', name: 'Fluffy', type: 'dog' }]);
-    });
+  test('getPets', async () => {
+    const result = await pet.getPets();
+    assert.deepStrictEqual(result, [{ id: 'pet-1', name: 'Fluffy', type: 'dog' }]);
   });
 });

--- a/test/tracker.test.js
+++ b/test/tracker.test.js
@@ -1,0 +1,39 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+
+describe('Tracker', () => {
+  describe('getAllTrackers', () => {
+    test('should fetch all trackers', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+
+  describe('getTracker', () => {
+    test('should fetch a tracker', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+
+  describe('getTrackerHistory', () => {
+    test('should fetch tracker history', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+
+  describe('getTrackerLocation', () => {
+    test('should fetch tracker location', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+
+  describe('getTrackerHardware', () => {
+    test('should fetch tracker hardware info', async () => {
+      // TODO: Add test implementation with https mocks
+      assert.ok(true);
+    });
+  });
+});

--- a/test/tracker.test.js
+++ b/test/tracker.test.js
@@ -70,38 +70,28 @@ describe('Tracker', () => {
         setGlobalDispatcher(originalDispatcher);
     });
 
-    describe('getAllTrackers', () => {
-        test('should fetch all trackers', async () => {
+    test('getAllTrackers', async () => {
         const result = await tracker.getAllTrackers();
-            assert.deepStrictEqual(result, { mock: 'all trackers' });
+        assert.deepStrictEqual(result, { mock: 'all trackers' });
     });
-  });
 
-  describe('getTracker', () => {
-    test('should fetch a tracker', async () => {
+    test('getTracker', async () => {
         const result = await tracker.getTracker('tracker-1');
         assert.deepStrictEqual(result, { id: 'tracker-1', name: 'Tracker 1' });
     });
-  });
 
-  describe('getTrackerHistory', () => {
-    test('should fetch tracker history', async () => {
+    test('getTrackerHistory', async () => {
         const result = await tracker.getTrackerHistory('tracker-1', 1000, 2000);
         assert.deepStrictEqual(result, { position: 'mock position data' });
     });
-  });
 
-  describe('getTrackerLocation', () => {
-    test('should fetch tracker location', async () => {
+    test('getTrackerLocation', async () => {
         const result = await tracker.getTrackerLocation('tracker-1');
         assert.deepStrictEqual(result, { latlong: [48.8566, 2.3522], address: { address: 'Paris, France' } });
     });
-  });
 
-  describe('getTrackerHardware', () => {
-    test('should fetch tracker hardware info', async () => {
+    test('getTrackerHardware', async () => {
         const result = await tracker.getTrackerHardware('tracker-1');
         assert.deepStrictEqual(result, { battery: 85, signal: 4 });
     });
-  });
 });

--- a/test/tracker.test.js
+++ b/test/tracker.test.js
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { MockAgent, setGlobalDispatcher } from 'undici';
+import { MockAgent, setGlobalDispatcher, getGlobalDispatcher } from 'undici';
 import * as tracker from '../src/tracker.js';
 
 // Set up global scope for modules
@@ -24,102 +24,84 @@ globalThis.isAuthenticated = function () {
     return false;
 }
 
-describe('Tracker', () => {
-    let mockAgent;
+// Set up mock agent and interceptors
+const trackerMock = new MockAgent();
+const mockPool = trackerMock.get('https://graph.tractive.com');
 
+// Set up all mock interceptors
+mockPool.intercept({
+    path: `/4/user/test-user-id/trackers`,
+    method: 'GET'
+}).reply(200, { mock: 'all trackers' });
+
+mockPool.intercept({
+    path: `/4/tracker/tracker-1`,
+    method: 'GET'
+}).reply(200, { id: 'tracker-1', name: 'Tracker 1' });
+
+mockPool.intercept({
+    path: `/4/tracker/tracker-1/positions?time_from=1000&time_to=2000&format=json_segments`,
+    method: 'GET'
+}).reply(200, [{ position: 'mock position data' }]);
+
+mockPool.intercept({
+    path: `/4/device_pos_report/tracker-1`,
+    method: 'GET'
+}).reply(200, { latlong: [48.8566, 2.3522] });
+
+mockPool.intercept({
+    path: `/4/platform/geo/address/location?latitude=48.8566&longitude=2.3522`,
+    method: 'GET'
+}).reply(200, { address: 'Paris, France' });
+
+mockPool.intercept({
+    path: `/4/device_hw_report/tracker-1`,
+    method: 'GET'
+}).reply(200, { battery: 85, signal: 4 });
+
+const originalDispatcher = getGlobalDispatcher();
+
+describe('Tracker', () => {
     beforeEach(() => {
-        mockAgent = new MockAgent();
-        setGlobalDispatcher(mockAgent);
+        setGlobalDispatcher(trackerMock);
     });
 
     afterEach(() => {
-        mockAgent.close();
+        setGlobalDispatcher(originalDispatcher);
     });
 
-  describe('getAllTrackers', () => {
-    test('should fetch all trackers', async () => {
-        const mockData = { mock: 'all trackers' };
-
-        const mockPool = mockAgent.get('https://graph.tractive.com');
-        mockPool.intercept({
-            path: `/4/user/test-user-id/trackers`,
-            method: 'GET'
-        }).reply(200, mockData);
-
+    describe('getAllTrackers', () => {
+        test('should fetch all trackers', async () => {
         const result = await tracker.getAllTrackers();
-        assert.deepStrictEqual(result, mockData);
+            assert.deepStrictEqual(result, { mock: 'all trackers' });
     });
   });
 
   describe('getTracker', () => {
     test('should fetch a tracker', async () => {
-        const mockData = { id: 'tracker-1', name: 'Tracker 1' };
-        const trackerId = 'tracker-1';
-
-        const mockPool = mockAgent.get('https://graph.tractive.com');
-        mockPool.intercept({
-            path: `/4/tracker/${trackerId}`,
-            method: 'GET'
-        }).reply(200, mockData);
-
-        const result = await tracker.getTracker(trackerId);
-        assert.deepStrictEqual(result, mockData);
+        const result = await tracker.getTracker('tracker-1');
+        assert.deepStrictEqual(result, { id: 'tracker-1', name: 'Tracker 1' });
     });
   });
 
   describe('getTrackerHistory', () => {
     test('should fetch tracker history', async () => {
-        const mockData = [{ position: 'mock position data' }];
-        const trackerId = 'tracker-1';
-        const from = 1000;
-        const to = 2000;
-
-        const mockPool = mockAgent.get('https://graph.tractive.com');
-        mockPool.intercept({
-            path: `/4/tracker/${trackerId}/positions?time_from=${from}&time_to=${to}&format=json_segments`,
-            method: 'GET'
-        }).reply(200, mockData);
-
-        const result = await tracker.getTrackerHistory(trackerId, from, to);
-        assert.deepStrictEqual(result, mockData[0]);
+        const result = await tracker.getTrackerHistory('tracker-1', 1000, 2000);
+        assert.deepStrictEqual(result, { position: 'mock position data' });
     });
   });
 
   describe('getTrackerLocation', () => {
     test('should fetch tracker location', async () => {
-        const mockLocationData = { latlong: [48.8566, 2.3522] };
-        const mockAddressData = { address: 'Paris, France' };
-        const trackerId = 'tracker-1';
-
-        const mockPool = mockAgent.get('https://graph.tractive.com');
-        mockPool.intercept({
-            path: `/4/device_pos_report/${trackerId}`,
-            method: 'GET'
-        }).reply(200, mockLocationData);
-
-        mockPool.intercept({
-            path: `/4/platform/geo/address/location?latitude=48.8566&longitude=2.3522`,
-            method: 'GET'
-        }).reply(200, mockAddressData);
-
-        const result = await tracker.getTrackerLocation(trackerId);
-        assert.deepStrictEqual(result, { ...mockLocationData, address: mockAddressData });
+        const result = await tracker.getTrackerLocation('tracker-1');
+        assert.deepStrictEqual(result, { latlong: [48.8566, 2.3522], address: { address: 'Paris, France' } });
     });
   });
 
   describe('getTrackerHardware', () => {
     test('should fetch tracker hardware info', async () => {
-        const mockData = { battery: 85, signal: 4 };
-        const trackerId = 'tracker-1';
-
-        const mockPool = mockAgent.get('https://graph.tractive.com');
-        mockPool.intercept({
-            path: `/4/device_hw_report/${trackerId}`,
-            method: 'GET'
-        }).reply(200, mockData);
-
-        const result = await tracker.getTrackerHardware(trackerId);
-        assert.deepStrictEqual(result, mockData);
+        const result = await tracker.getTrackerHardware('tracker-1');
+        assert.deepStrictEqual(result, { battery: 85, signal: 4 });
     });
   });
 });

--- a/test/tracker.test.js
+++ b/test/tracker.test.js
@@ -1,39 +1,125 @@
-import { test, describe } from 'node:test';
+import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
+import { MockAgent, setGlobalDispatcher } from 'undici';
+import * as tracker from '../src/tracker.js';
+
+// Set up global scope for modules
+globalThis.accountDetails = {
+    uid: "test-user-id",
+    token: "test-token"
+};
+
+globalThis.gloOpts = {
+    method: "GET",
+    hostname: "graph.tractive.com",
+    headers: {
+        "X-Tractive-Client": "mock-client",
+        "Authorization": `Bearer mock-auth`,
+        "content-type": "application/json"
+    }
+};
+
+globalThis.isAuthenticated = function () {
+    if (accountDetails?.token) return true;
+    return false;
+}
 
 describe('Tracker', () => {
+    let mockAgent;
+
+    beforeEach(() => {
+        mockAgent = new MockAgent();
+        setGlobalDispatcher(mockAgent);
+    });
+
+    afterEach(() => {
+        mockAgent.close();
+    });
+
   describe('getAllTrackers', () => {
     test('should fetch all trackers', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const mockData = { mock: 'all trackers' };
+
+        const mockPool = mockAgent.get('https://graph.tractive.com');
+        mockPool.intercept({
+            path: `/4/user/test-user-id/trackers`,
+            method: 'GET'
+        }).reply(200, mockData);
+
+        const result = await tracker.getAllTrackers();
+        assert.deepStrictEqual(result, mockData);
     });
   });
 
   describe('getTracker', () => {
     test('should fetch a tracker', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const mockData = { id: 'tracker-1', name: 'Tracker 1' };
+        const trackerId = 'tracker-1';
+
+        const mockPool = mockAgent.get('https://graph.tractive.com');
+        mockPool.intercept({
+            path: `/4/tracker/${trackerId}`,
+            method: 'GET'
+        }).reply(200, mockData);
+
+        const result = await tracker.getTracker(trackerId);
+        assert.deepStrictEqual(result, mockData);
     });
   });
 
   describe('getTrackerHistory', () => {
     test('should fetch tracker history', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const mockData = [{ position: 'mock position data' }];
+        const trackerId = 'tracker-1';
+        const from = 1000;
+        const to = 2000;
+
+        const mockPool = mockAgent.get('https://graph.tractive.com');
+        mockPool.intercept({
+            path: `/4/tracker/${trackerId}/positions?time_from=${from}&time_to=${to}&format=json_segments`,
+            method: 'GET'
+        }).reply(200, mockData);
+
+        const result = await tracker.getTrackerHistory(trackerId, from, to);
+        assert.deepStrictEqual(result, mockData[0]);
     });
   });
 
   describe('getTrackerLocation', () => {
     test('should fetch tracker location', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const mockLocationData = { latlong: [48.8566, 2.3522] };
+        const mockAddressData = { address: 'Paris, France' };
+        const trackerId = 'tracker-1';
+
+        const mockPool = mockAgent.get('https://graph.tractive.com');
+        mockPool.intercept({
+            path: `/4/device_pos_report/${trackerId}`,
+            method: 'GET'
+        }).reply(200, mockLocationData);
+
+        mockPool.intercept({
+            path: `/4/platform/geo/address/location?latitude=48.8566&longitude=2.3522`,
+            method: 'GET'
+        }).reply(200, mockAddressData);
+
+        const result = await tracker.getTrackerLocation(trackerId);
+        assert.deepStrictEqual(result, { ...mockLocationData, address: mockAddressData });
     });
   });
 
   describe('getTrackerHardware', () => {
     test('should fetch tracker hardware info', async () => {
-      // TODO: Add test implementation with https mocks
-      assert.ok(true);
+        const mockData = { battery: 85, signal: 4 };
+        const trackerId = 'tracker-1';
+
+        const mockPool = mockAgent.get('https://graph.tractive.com');
+        mockPool.intercept({
+            path: `/4/device_hw_report/${trackerId}`,
+            method: 'GET'
+        }).reply(200, mockData);
+
+        const result = await tracker.getTrackerHardware(trackerId);
+        assert.deepStrictEqual(result, mockData);
     });
   });
 });


### PR DESCRIPTION
This changes from `https.request` to `fetch` for making requests to the api.

There should be no difference to usage, however it will require Node 18.x+.

Benefits: 
* simplifies json handling, avoids some potential edge cases
* improved performance + memory usage
* syntax - more concise async await

### Modules

I also switched from cjs to modules, index.js exports a single default object to match the module.exports from before.

### Testing

I added some rudimentary testing for each of the endpoints.  It uses the builtin node test runner so can be run with `node --test`.

<details>

<summary>Test Results</summary>

```bash
node --test 
▶ Account
  ✔ getAccountInfo (3.42675ms)
  ✔ getAccountSubscriptions (0.794166ms)
  ✔ getAccountShares (0.463125ms)
✔ Account (5.052375ms)
▶ Commands
  ✔ liveOn (3.438708ms)
  ✔ liveOff (0.777958ms)
  ✔ LEDOn (1.0605ms)
  ✔ LEDOff (0.722542ms)
  ✔ BuzzerOn (0.485334ms)
  ✔ BuzzerOff (0.592875ms)
✔ Commands (7.515542ms)
▶ Pet
  ✔ getPets (3.356416ms)
✔ Pet (3.664333ms)
▶ Tracker
  ✔ getAllTrackers (3.883375ms)
  ✔ getTracker (1.221292ms)
  ✔ getTrackerHistory (0.618958ms)
  ✔ getTrackerLocation (0.75275ms)
  ✔ getTrackerHardware (0.335ms)
✔ Tracker (7.238ms)
ℹ tests 15
ℹ suites 4
ℹ pass 15
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 90.989666
```

</details>


### Geofence methods

`getTrackerGeofences` & `getGeofence` were defined in index.js, but weren't exported.  I've exported them and tested if they work.